### PR TITLE
Rename requestUrl to request path

### DIFF
--- a/source/source/lib/handlers/FileHandler.php
+++ b/source/source/lib/handlers/FileHandler.php
@@ -49,7 +49,7 @@ abstract class FileHandler extends RequestHandler
     protected function processsRequest(RequestInterface $request)
     {
         try {
-            $this->validateFilePath($request->requestUrl());
+            $this->validateFilePath($request->requestPath());
             $filePath = $this->getFilePath($request);
             $this->checkFileExistance($filePath);
 

--- a/source/source/lib/handlers/ProxyRequestHandler.php
+++ b/source/source/lib/handlers/ProxyRequestHandler.php
@@ -64,7 +64,7 @@ class ProxyRequestHandler extends RequestHandler
     protected function processsRequest(RequestInterface $request)
     {
         // Build full URL from target host and request path
-        $url = $this->server->targetHost() . $request->requestUrl();
+        $url = $this->server->targetHost() . $request->requestPath();
         if ($request->query()) {
             $url .= '?' . $request->query();
         }

--- a/source/source/lib/handlers/StaticFileHandler.php
+++ b/source/source/lib/handlers/StaticFileHandler.php
@@ -9,7 +9,7 @@ use Tent\Models\RequestInterface;
  * FileHandler that serves static files based on the request URL and a base directory.
  *
  * This handler returns the contents of a file located by combining the base directory
- * (provided by FolderLocation) and the requestUrl from the incoming request. It is
+ * (provided by FolderLocation) and the requestPath from the incoming request. It is
  * typically used to serve static assets such as HTML, CSS, JS, images, etc.
  */
 class StaticFileHandler extends FileHandler
@@ -47,6 +47,6 @@ class StaticFileHandler extends FileHandler
      */
     protected function getFilePath(RequestInterface $request)
     {
-        return $this->folderLocation->basePath() . $request->requestUrl();
+        return $this->folderLocation->basePath() . $request->requestPath();
     }
 }

--- a/source/source/lib/models/ProcessingRequest.php
+++ b/source/source/lib/models/ProcessingRequest.php
@@ -31,7 +31,7 @@ class ProcessingRequest implements RequestInterface
     private $requestMethod;
     private $body;
     private $headers;
-    private $requestUrl;
+    private $requestPath;
     private $query;
 
     /**
@@ -42,7 +42,7 @@ class ProcessingRequest implements RequestInterface
         'requestMethod',
         'body',
         'headers',
-        'requestUrl',
+        'requestPath',
         'query',
     ];
 
@@ -58,7 +58,7 @@ class ProcessingRequest implements RequestInterface
      *     'requestMethod' => 'POST',
      *     'body' => '{"foo":"bar"}',
      *     'headers' => ['X-Test' => 'ok'],
-     *     'requestUrl' => '/api/test',
+     *     'requestPath' => '/api/test',
      *     'query' => 'a=1&b=2',
      * ]);
      * </code>
@@ -143,14 +143,14 @@ class ProcessingRequest implements RequestInterface
      *
      * @return string|null The path portion of the request URL or null if no request is set
      *
-     * @see RequestInterface::requestUrl()
+     * @see RequestInterface::requestPath()
      */
-    public function requestUrl()
+    public function requestPath()
     {
-        if ($this->requestUrl === null && $this->request) {
-            $this->requestUrl = $this->request->requestUrl();
+        if ($this->requestPath === null && $this->request) {
+            $this->requestPath = $this->request->requestPath();
         }
-        return $this->requestUrl;
+        return $this->requestPath;
     }
 
     /**

--- a/source/source/lib/models/Request.php
+++ b/source/source/lib/models/Request.php
@@ -79,12 +79,12 @@ class Request implements RequestInterface
      *
      * @return string The path portion of the request URL
      *
-     * @see RequestInterface::requestUrl()
+     * @see RequestInterface::requestPath()
      */
-    public function requestUrl()
+    public function requestPath()
     {
-        if (isset($this->options['requestUrl'])) {
-            return $this->options['requestUrl'];
+        if (isset($this->options['requestPath'])) {
+            return $this->options['requestPath'];
         }
         $uri = $_SERVER['REQUEST_URI'];
         $parts = parse_url($uri);

--- a/source/source/lib/models/RequestInterface.php
+++ b/source/source/lib/models/RequestInterface.php
@@ -26,7 +26,7 @@ interface RequestInterface
      * Returns the request URL path (e.g., /index.html).
      * @return string
      */
-    public function requestUrl();
+    public function requestPath();
 
     /**
      * Returns the query string from the request URL.

--- a/source/source/lib/models/RequestMatcher.php
+++ b/source/source/lib/models/RequestMatcher.php
@@ -84,12 +84,12 @@ class RequestMatcher
             return true;
         }
 
-        $requestUrl = $request->requestUrl();
+        $requestPath = $request->requestPath();
 
         if ($this->matchType === 'exact') {
-            return $requestUrl === $this->requestUri;
+            return $requestPath === $this->requestUri;
         } elseif ($this->matchType === 'begins_with') {
-            return strpos($requestUrl, $this->requestUri) === 0;
+            return strpos($requestPath, $this->requestUri) === 0;
         }
 
         return false;

--- a/source/tests/support/handlers/RequestToBodyHandler.php
+++ b/source/tests/support/handlers/RequestToBodyHandler.php
@@ -21,7 +21,7 @@ class RequestToBodyHandler extends RequestHandler
     protected function processsRequest(RequestInterface $request)
     {
         $body = json_encode([
-            'uri' => $request->requestUrl(),
+            'uri' => $request->requestPath(),
             'query' => $request->query(),
             'method' => $request->requestMethod(),
             'headers' => $request->headers(),

--- a/source/tests/unit/lib/Configuration/ConfigurationBuildRuleTest.php
+++ b/source/tests/unit/lib/Configuration/ConfigurationBuildRuleTest.php
@@ -35,12 +35,12 @@ class ConfigurationBuildRuleTest extends TestCase
 
         $requestGet = new Request([
             'requestMethod' => 'GET',
-            'requestUrl' => '/index.html',
+            'requestPath' => '/index.html',
         ]);
 
         $requestPost = new Request([
             'requestMethod' => 'POST',
-            'requestUrl' => '/submit/123',
+            'requestPath' => '/submit/123',
         ]);
 
         $this->assertTrue($rule->match($requestGet));

--- a/source/tests/unit/lib/handlers/FixedFileHandler/FixedFileHandlerGeneralTest.php
+++ b/source/tests/unit/lib/handlers/FixedFileHandler/FixedFileHandlerGeneralTest.php
@@ -17,7 +17,7 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/content.html');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -30,7 +30,7 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/data.json');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url.json']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url.json']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -43,7 +43,7 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/image.gif');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url.gif']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url.gif']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -56,7 +56,7 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/nonexistent.txt');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url.txt']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url.txt']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(MissingResponse::class, $response);
@@ -66,7 +66,7 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/style.css');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url.css']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url.css']);
         $response = $handler->handleRequest($request);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -79,8 +79,8 @@ class FixedFileHandlerGeneralTest extends \PHPUnit\Framework\TestCase
     {
         $handler = new FixedFileHandler('./tests/fixtures/content.html');
 
-        $request = new ProcessingRequest(['requestUrl' => '/some-url.html']);
-        $request = new ProcessingRequest(['requestUrl' => '../etc/passwd']);
+        $request = new ProcessingRequest(['requestPath' => '/some-url.html']);
+        $request = new ProcessingRequest(['requestPath' => '../etc/passwd']);
 
         $response = $handler->handleRequest($request);
         $this->assertInstanceOf(ForbiddenResponse::class, $response);

--- a/source/tests/unit/lib/handlers/ProxyRequestHandler/ProxyRequestHandlerGeneralTest.php
+++ b/source/tests/unit/lib/handlers/ProxyRequestHandler/ProxyRequestHandlerGeneralTest.php
@@ -18,7 +18,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
             'headers' => [],
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'query' => ''
         ]);
         $httpClient = $this->createMockHttpClient(
@@ -38,7 +38,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
     {
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'headers' => [],
             'query' => 'page=1&limit=10'
         ]);
@@ -59,7 +59,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
     {
         $request = new ProcessingRequest([
             'requestMethod' => 'POST',
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'query' => '',
             'headers' => [
                 'Content-Type' => 'application/json',
@@ -89,7 +89,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
     {
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'query' => '',
             'headers' => []
         ]);
@@ -116,7 +116,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
     {
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'query' => '',
             'headers' => []
         ]);
@@ -137,7 +137,7 @@ class ProxyRequestHandlerGeneralTest extends TestCase
     {
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/api/users',
+            'requestPath' => '/api/users',
             'query' => '',
             'headers' => []
         ]);

--- a/source/tests/unit/lib/handlers/RequestHandler/RequestHandlerMiddlewareTest.php
+++ b/source/tests/unit/lib/handlers/RequestHandler/RequestHandlerMiddlewareTest.php
@@ -22,7 +22,7 @@ class RequestHandlerMiddlewareTest extends TestCase
 
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/test',
+            'requestPath' => '/test',
             'headers' => [
                 'Accept' => 'application/json',
             ]

--- a/source/tests/unit/lib/handlers/StaticFileHandler/StaticFileHandlerGeneralTest.php
+++ b/source/tests/unit/lib/handlers/StaticFileHandler/StaticFileHandlerGeneralTest.php
@@ -47,7 +47,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/test.txt');
+        $request->method('requestPath')->willReturn('/test.txt');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -63,7 +63,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/nonexistent.txt');
+        $request->method('requestPath')->willReturn('/nonexistent.txt');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -80,7 +80,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/index.html');
+        $request->method('requestPath')->willReturn('/index.html');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -98,7 +98,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/style.css');
+        $request->method('requestPath')->willReturn('/style.css');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -116,7 +116,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/script.js');
+        $request->method('requestPath')->willReturn('/script.js');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -134,7 +134,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/data.json');
+        $request->method('requestPath')->willReturn('/data.json');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -152,7 +152,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/image.png');
+        $request->method('requestPath')->willReturn('/image.png');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -170,7 +170,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/image.jpg');
+        $request->method('requestPath')->willReturn('/image.jpg');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -188,7 +188,7 @@ class StaticFileHandlerGeneralTest extends TestCase
         $handler = new StaticFileHandler($location);
 
         $request = $this->createMock(Request::class);
-        $request->method('requestUrl')->willReturn('/subdir');
+        $request->method('requestPath')->willReturn('/subdir');
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);
@@ -201,7 +201,7 @@ class StaticFileHandlerGeneralTest extends TestCase
     {
         $location = new FolderLocation($this->testDir);
         $handler = new StaticFileHandler($location);
-        $request = new Request(['requestUrl' => '../etc/passwd']);
+        $request = new Request(['requestPath' => '../etc/passwd']);
         $processingRequest = new ProcessingRequest(['request' => $request]);
 
         $response = $handler->handleRequest($processingRequest);

--- a/source/tests/unit/lib/models/ProcessingRequest/ProcessingRequestGeneralTest.php
+++ b/source/tests/unit/lib/models/ProcessingRequest/ProcessingRequestGeneralTest.php
@@ -27,31 +27,31 @@ class ProcessingRequestGeneralTest extends TestCase
         $this->assertEquals('POST', $processingRequest->requestMethod());
     }
 
-    public function testRequestUrlReturnsPath()
+    public function testRequestPathReturnsPath()
     {
         $request = new Request([
-            'requestUrl' => '/api/users'
+            'requestPath' => '/api/users'
         ]);
         $processingRequest = new ProcessingRequest(['request' => $request]);
-        $this->assertEquals('/api/users', $processingRequest->requestUrl());
+        $this->assertEquals('/api/users', $processingRequest->requestPath());
     }
 
-    public function testRequestUrlReturnsPathWithoutQueryString()
+    public function testRequestPathReturnsPathWithoutQueryString()
     {
         $request = new Request([
-            'requestUrl' => '/api/users'
+            'requestPath' => '/api/users'
         ]);
         $processingRequest = new ProcessingRequest(['request' => $request]);
-        $this->assertEquals('/api/users', $processingRequest->requestUrl());
+        $this->assertEquals('/api/users', $processingRequest->requestPath());
     }
 
-    public function testRequestUrlReturnsRootWhenEmpty()
+    public function testRequestPathReturnsRootWhenEmpty()
     {
         $request = new Request([
-            'requestUrl' => '/'
+            'requestPath' => '/'
         ]);
         $processingRequest = new ProcessingRequest(['request' => $request]);
-        $this->assertEquals('/', $processingRequest->requestUrl());
+        $this->assertEquals('/', $processingRequest->requestPath());
     }
 
     public function testQueryReturnsQueryString()
@@ -72,14 +72,14 @@ class ProcessingRequestGeneralTest extends TestCase
         $this->assertEquals('', $processingRequest->query());
     }
 
-    public function testRequestUrlWithComplexPath()
+    public function testRequestPathWithComplexPath()
     {
         $request = new Request([
-            'requestUrl' => '/api/v1/users/123/posts',
+            'requestPath' => '/api/v1/users/123/posts',
             'query' => 'filter=active'
         ]);
         $processingRequest = new ProcessingRequest(['request' => $request]);
-        $this->assertEquals('/api/v1/users/123/posts', $processingRequest->requestUrl());
+        $this->assertEquals('/api/v1/users/123/posts', $processingRequest->requestPath());
         $this->assertEquals('filter=active', $processingRequest->query());
     }
 
@@ -89,20 +89,20 @@ class ProcessingRequestGeneralTest extends TestCase
             'requestMethod' => 'PUT',
             'body' => '{"name":"test"}',
             'headers' => ['Content-Type' => 'application/json'],
-            'requestUrl' => '/api/v1/users/123/posts',
+            'requestPath' => '/api/v1/users/123/posts',
             'query' => 'filter=active'
         ]);
         $processingRequest = new ProcessingRequest([
             'request' => $request,
             'requestMethod' => 'GET',
             'body' => '',
-            'requestUrl' => '/api/v1/user',
+            'requestPath' => '/api/v1/user',
             'headers' => ['Content-Type' => 'text/html'],
             'query' => 'filter=disabled'
         ]);
         $this->assertEquals('GET', $processingRequest->requestMethod());
         $this->assertEquals('', $processingRequest->body());
-        $this->assertEquals('/api/v1/user', $processingRequest->requestUrl());
+        $this->assertEquals('/api/v1/user', $processingRequest->requestPath());
         $this->assertEquals(['Content-Type' => 'text/html'], $processingRequest->headers());
         $this->assertEquals('filter=disabled', $processingRequest->query());
     }
@@ -113,7 +113,7 @@ class ProcessingRequestGeneralTest extends TestCase
         $this->assertNull($processingRequest->requestMethod());
         $this->assertNull($processingRequest->body());
         $this->assertNull($processingRequest->headers());
-        $this->assertNull($processingRequest->requestUrl());
+        $this->assertNull($processingRequest->requestPath());
         $this->assertNull($processingRequest->query());
     }
 }

--- a/source/tests/unit/lib/models/RequestMatcher/RequestMatcherBuildTest.php
+++ b/source/tests/unit/lib/models/RequestMatcher/RequestMatcherBuildTest.php
@@ -19,7 +19,7 @@ class RequestMatcherBuildTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestMethod')->willReturn('GET');
-        $request->method('requestUrl')->willReturn('/users');
+        $request->method('requestPath')->willReturn('/users');
         $this->assertTrue($matcher->matches($request));
     }
 
@@ -33,7 +33,7 @@ class RequestMatcherBuildTest extends TestCase
 
         $request = $this->createMock(Request::class);
         $request->method('requestMethod')->willReturn('POST');
-        $request->method('requestUrl')->willReturn('/api');
+        $request->method('requestPath')->willReturn('/api');
         $this->assertTrue($matcher->matches($request));
     }
 }

--- a/source/tests/unit/lib/models/RequestMatcher/RequestMatcherGeneralTest.php
+++ b/source/tests/unit/lib/models/RequestMatcher/RequestMatcherGeneralTest.php
@@ -132,7 +132,7 @@ class RequestMatcherGeneralTest extends TestCase
     {
         $mock = $this->createMock(Request::class);
         $mock->method('requestMethod')->willReturn($method);
-        $mock->method('requestUrl')->willReturn($url);
+        $mock->method('requestPath')->willReturn($url);
         return $mock;
     }
 }

--- a/source/tests/unit/lib/models/RequestTest.php
+++ b/source/tests/unit/lib/models/RequestTest.php
@@ -39,31 +39,31 @@ class RequestTest extends TestCase
         $this->assertEquals('POST', $request->requestMethod());
     }
 
-    public function testRequestUrlReturnsPath()
+    public function testRequestPathReturnsPath()
     {
         $_SERVER['REQUEST_URI'] = '/api/users';
 
         $request = new Request();
 
-        $this->assertEquals('/api/users', $request->requestUrl());
+        $this->assertEquals('/api/users', $request->requestPath());
     }
 
-    public function testRequestUrlReturnsPathWithoutQueryString()
+    public function testRequestPathReturnsPathWithoutQueryString()
     {
         $_SERVER['REQUEST_URI'] = '/api/users?page=1&limit=10';
 
         $request = new Request();
 
-        $this->assertEquals('/api/users', $request->requestUrl());
+        $this->assertEquals('/api/users', $request->requestPath());
     }
 
-    public function testRequestUrlReturnsRootWhenEmpty()
+    public function testRequestPathReturnsRootWhenEmpty()
     {
         $_SERVER['REQUEST_URI'] = '/';
 
         $request = new Request();
 
-        $this->assertEquals('/', $request->requestUrl());
+        $this->assertEquals('/', $request->requestPath());
     }
 
     public function testQueryReturnsQueryString()
@@ -84,13 +84,13 @@ class RequestTest extends TestCase
         $this->assertEquals('', $request->query());
     }
 
-    public function testRequestUrlWithComplexPath()
+    public function testRequestPathWithComplexPath()
     {
         $_SERVER['REQUEST_URI'] = '/api/v1/users/123/posts?filter=active';
 
         $request = new Request();
 
-        $this->assertEquals('/api/v1/users/123/posts', $request->requestUrl());
+        $this->assertEquals('/api/v1/users/123/posts', $request->requestPath());
         $this->assertEquals('filter=active', $request->query());
     }
 }

--- a/source/tests/unit/lib/models/Rule/RuleBuildTest.php
+++ b/source/tests/unit/lib/models/Rule/RuleBuildTest.php
@@ -28,12 +28,12 @@ class RuleBuildTest extends TestCase
 
         $requestGet = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/index.html',
+            'requestPath' => '/index.html',
         ]);
 
         $requestPost = new ProcessingRequest([
             'requestMethod' => 'POST',
-            'requestUrl' => '/submit/123',
+            'requestPath' => '/submit/123',
         ]);
 
         $this->assertTrue($rule->match($requestGet));
@@ -55,7 +55,7 @@ class RuleBuildTest extends TestCase
 
         $request = new ProcessingRequest([
             'requestMethod' => 'GET',
-            'requestUrl' => '/index.html',
+            'requestPath' => '/index.html',
         ]);
 
         $handler = $rule->handler();

--- a/source/tests/unit/lib/models/Rule/RuleGeneralTest.php
+++ b/source/tests/unit/lib/models/Rule/RuleGeneralTest.php
@@ -14,7 +14,7 @@ class RuleGeneralTest extends TestCase
     {
         $request = $this->createMock(Request::class);
         $request->method('requestMethod')->willReturn('GET');
-        $request->method('requestUrl')->willReturn('/test');
+        $request->method('requestPath')->willReturn('/test');
 
         $handler = $this->createMock(RequestHandler::class);
 
@@ -30,7 +30,7 @@ class RuleGeneralTest extends TestCase
     {
         $request = $this->createMock(Request::class);
         $request->method('requestMethod')->willReturn('GET');
-        $request->method('requestUrl')->willReturn('/test');
+        $request->method('requestPath')->willReturn('/test');
 
         $handler = $this->createMock(RequestHandler::class);
 
@@ -66,7 +66,7 @@ class RuleGeneralTest extends TestCase
     {
         $request = $this->createMock(Request::class);
         $request->method('requestMethod')->willReturn('GET');
-        $request->method('requestUrl')->willReturn('/test');
+        $request->method('requestPath')->willReturn('/test');
 
         $handler = $this->createMock(RequestHandler::class);
 

--- a/source/tests/unit/lib/service/RequestProcessorTest.php
+++ b/source/tests/unit/lib/service/RequestProcessorTest.php
@@ -54,7 +54,7 @@ class RequestProcessorTest extends TestCase
 
         // Create a request to /index.html using named parameters
         $request = new Request([
-            'requestUrl' => '/index.html',
+            'requestPath' => '/index.html',
             'requestMethod' => 'GET'
         ]);
         $response = RequestProcessor::handleRequest($request);
@@ -69,7 +69,7 @@ class RequestProcessorTest extends TestCase
     public function testProxyRequestHandlerForwardsToHttpbin()
     {
         $request = new Request([
-            'requestUrl' => '/get',
+            'requestPath' => '/get',
             'requestMethod' => 'GET',
             'query' => '',
             'headers' => []
@@ -90,7 +90,7 @@ class RequestProcessorTest extends TestCase
     {
         // No rules added, so fallback handler should be used
         $request = new Request([
-            'requestUrl' => '/other',
+            'requestPath' => '/other',
             'requestMethod' => 'GET'
         ]);
         $response = RequestProcessor::handleRequest($request);


### PR DESCRIPTION
# Rename requestUrl to requestPath

This pull request renames the method and related variables from `requestUrl` to `requestPath` throughout the codebase. The new name more accurately reflects that the value represents only the path portion of the request, not the full URL.

**Summary of changes:**
- Renamed all occurrences of `requestUrl()` to `requestPath()` in interfaces, implementations, and tests.
- Updated variable names, docblocks, and test cases to match the new naming.
- No changes to logic or behavior; this is a naming/clarity refactor only.

This improves code clarity and avoids confusion between a full URL and just the path segment.
