### PR TITLE
Add RenameHeaderMiddleware (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Configuration::buildRule([
 ### Built-in Middlewares
 
 - **SetHeadersMiddleware**: Sets or overrides request headers (e.g., Host, X-Test).
+- **RenameHeaderMiddleware**: Renames a request header by copying its value to a new name and removing the original.
 - **SetPathMiddleware**: Changes the request path, useful for serving a fixed file with StaticFileHandler.
 - **FileCacheMiddleware**: Caches responses matching configured HTTP codes (now configured via 'matchers'; 'httpCodes' is deprecated).
 

--- a/docs/creating-middlewares.md
+++ b/docs/creating-middlewares.md
@@ -243,6 +243,20 @@ Sets or overrides request headers before the request is forwarded.
 
 **When to use**: When the backend service expects a specific `Host` header, or when you need to inject custom headers for authentication or routing.
 
+### `RenameHeaderMiddleware`
+
+Renames a request header by copying its value to a new header name and removing the original.
+
+```php
+[
+    'class' => 'Tent\\Middlewares\\RenameHeaderMiddleware',
+    'from'  => 'Host',
+    'to'    => 'X-Original-Host'
+]
+```
+
+**When to use**: When you need to preserve the original value of a header under a different name before overriding it (e.g., saving the original `Host` as `X-Original-Host`).
+
 ### `SetPathMiddleware`
 
 Rewrites the request path before it is processed by the handler.

--- a/source/source/lib/middlewares/RenameHeaderMiddleware.php
+++ b/source/source/lib/middlewares/RenameHeaderMiddleware.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tent\Middlewares;
+
+use Tent\Models\ProcessingRequest;
+
+/**
+ * Middleware to rename a request header in a ProcessingRequest.
+ *
+ * Reads the value of the `from` header and sets it under the `to` header,
+ * then removes the original `from` header. If the `from` header is not present,
+ * the request is left unchanged.
+ *
+ * ## Usage Example (in configuration)
+ *
+ * ```php
+ * use Tent\Configuration;
+ *
+ * Configuration::buildRule([
+ *     'handler' => [
+ *         'type' => 'proxy',
+ *         'host' => 'http://api:80'
+ *     ],
+ *     'matchers' => [
+ *         ['method' => 'GET', 'uri' => '/persons', 'type' => 'exact']
+ *     ],
+ *     'middlewares' => [
+ *         [
+ *             'class' => 'Tent\\Middlewares\\RenameHeaderMiddleware',
+ *             'from' => 'Host',
+ *             'to'   => 'X-Original-Host'
+ *         ]
+ *     ]
+ * ]);
+ * ```
+ *
+ * The middleware can also be instantiated directly:
+ *
+ * ```php
+ * $middleware = RenameHeaderMiddleware::build([
+ *     'from' => 'Host',
+ *     'to'   => 'X-Original-Host'
+ * ]);
+ * ```
+ */
+class RenameHeaderMiddleware extends Middleware
+{
+    /**
+     * @var string The header name to read from.
+     */
+    private $from;
+
+    /**
+     * @var string The header name to write to.
+     */
+    private $to;
+
+    /**
+     * @param string $from The original header name.
+     * @param string $to   The new header name.
+     */
+    public function __construct(string $from, string $to)
+    {
+        $this->from = $from;
+        $this->to   = $to;
+    }
+
+    /**
+     * Builds a RenameHeaderMiddleware using named parameters.
+     *
+     * Example:
+     *   RenameHeaderMiddleware::build(['from' => 'Host', 'to' => 'X-Original-Host'])
+     *
+     * @param array $attributes Associative array with keys 'from' and 'to' (strings).
+     * @return RenameHeaderMiddleware
+     */
+    public static function build(array $attributes): RenameHeaderMiddleware
+    {
+        return new self($attributes['from'], $attributes['to']);
+    }
+
+    /**
+     * Renames a header in the ProcessingRequest.
+     *
+     * Copies the value of the `from` header to the `to` header and removes
+     * the original `from` header. Does nothing if the `from` header is absent.
+     *
+     * @param ProcessingRequest $request The request to process.
+     * @return ProcessingRequest The modified request.
+     */
+    public function processRequest(ProcessingRequest $request): ProcessingRequest
+    {
+        $headers = $request->headers();
+
+        if (array_key_exists($this->from, $headers)) {
+            $request->setHeader($this->to, $headers[$this->from]);
+            $request->removeHeader($this->from);
+        }
+
+        return $request;
+    }
+}

--- a/source/source/lib/models/ProcessingRequest.php
+++ b/source/source/lib/models/ProcessingRequest.php
@@ -172,6 +172,22 @@ class ProcessingRequest implements RequestInterface
     }
 
     /**
+     * Removes a header from the cached headers array.
+     *
+     * If the header does not exist, this method does nothing.
+     *
+     * @param string $name The header name to remove.
+     *
+     * @return void
+     */
+    public function removeHeader(string $name): void
+    {
+        $this->headers();
+
+        unset($this->headers[$name]);
+    }
+
+    /**
      * Sets the request path value.
      *
      * This method allows you to override or set the path portion of the request URL

--- a/source/source/loader.php
+++ b/source/source/loader.php
@@ -25,6 +25,7 @@ require_once __DIR__ . '/lib/http/CurlHttpExecutor/Post.php';
 require_once __DIR__ . '/lib/http/CurlHttpExecutor/Put.php';
 require_once __DIR__ . '/lib/middlewares/Middleware.php';
 require_once __DIR__ . '/lib/middlewares/FileCacheMiddleware.php';
+require_once __DIR__ . '/lib/middlewares/RenameHeaderMiddleware.php';
 require_once __DIR__ . '/lib/middlewares/SetHeadersMiddleware.php';
 require_once __DIR__ . '/lib/middlewares/SetPathMiddleware.php';
 require_once __DIR__ . '/lib/models/FolderLocation.php';

--- a/source/tests/unit/lib/middlewares/RenameHeaderMiddleware/RenameHeaderMiddlewareBuildTest.php
+++ b/source/tests/unit/lib/middlewares/RenameHeaderMiddleware/RenameHeaderMiddlewareBuildTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tent\Tests\Middlewares\RenameHeaderMiddleware;
+
+require_once __DIR__ . '/../../../../support/loader.php';
+
+use PHPUnit\Framework\TestCase;
+use Tent\Middlewares\RenameHeaderMiddleware;
+use Tent\Models\ProcessingRequest;
+
+class RenameHeaderMiddlewareBuildTest extends TestCase
+{
+    public function testBuildCreatesInstance()
+    {
+        $middleware = RenameHeaderMiddleware::build([
+            'from' => 'Host',
+            'to'   => 'X-Original-Host',
+        ]);
+
+        $this->assertInstanceOf(RenameHeaderMiddleware::class, $middleware);
+    }
+
+    public function testBuildAndProcessing()
+    {
+        $middleware = RenameHeaderMiddleware::build([
+            'from' => 'Host',
+            'to'   => 'X-Original-Host',
+        ]);
+
+        $request = new ProcessingRequest(['headers' => ['Host' => 'example.com']]);
+        $modifiedRequest = $middleware->processRequest($request);
+
+        $this->assertEquals('example.com', $modifiedRequest->headers()['X-Original-Host']);
+        $this->assertArrayNotHasKey('Host', $modifiedRequest->headers());
+    }
+}

--- a/source/tests/unit/lib/middlewares/RenameHeaderMiddleware/RenameHeaderMiddlewareTest.php
+++ b/source/tests/unit/lib/middlewares/RenameHeaderMiddleware/RenameHeaderMiddlewareTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tent\Tests\Middlewares\RenameHeaderMiddleware;
+
+require_once __DIR__ . '/../../../../support/loader.php';
+
+use PHPUnit\Framework\TestCase;
+use Tent\Middlewares\RenameHeaderMiddleware;
+use Tent\Models\ProcessingRequest;
+
+class RenameHeaderMiddlewareTest extends TestCase
+{
+    public function testRenamesHeader()
+    {
+        $request = new ProcessingRequest([
+            'headers' => [
+                'Host'       => 'original_host',
+                'User-Agent' => 'PHPUnit',
+            ]
+        ]);
+
+        $middleware = new RenameHeaderMiddleware('Host', 'X-Original-Host');
+        $result = $middleware->processRequest($request);
+
+        $this->assertSame($request, $result);
+        $this->assertEquals(
+            [
+                'X-Original-Host' => 'original_host',
+                'User-Agent'      => 'PHPUnit',
+            ],
+            $result->headers()
+        );
+    }
+
+    public function testDoesNothingWhenFromHeaderIsMissing()
+    {
+        $requestHeaders = [
+            'User-Agent' => 'PHPUnit',
+        ];
+
+        $request = new ProcessingRequest([
+            'headers' => $requestHeaders
+        ]);
+
+        $middleware = new RenameHeaderMiddleware('Host', 'X-Original-Host');
+        $result = $middleware->processRequest($request);
+
+        $this->assertSame($request, $result);
+        $this->assertEquals($requestHeaders, $result->headers());
+    }
+
+    public function testCaseSensitiveHeaderLookup()
+    {
+        $request = new ProcessingRequest([
+            'headers' => [
+                'host' => 'lowercase_host',
+            ]
+        ]);
+
+        $middleware = new RenameHeaderMiddleware('Host', 'X-Original-Host');
+        $result = $middleware->processRequest($request);
+
+        // 'Host' (capital H) is absent; 'host' (lowercase) must remain untouched
+        $this->assertEquals(['host' => 'lowercase_host'], $result->headers());
+    }
+}


### PR DESCRIPTION
Adds a middleware that renames a request header — copies the value from one header name to another and removes the original — useful for preserving headers before overriding them (e.g. saving `Host` as `X-Original-Host`).

## Changes

- **`ProcessingRequest`** — new `removeHeader(string $name): void` method
- **`RenameHeaderMiddleware`** *(new)* — extends `Middleware`, initialized with `from`/`to` header names; no-ops when `from` is absent; includes static `build(array $attributes)` factory
- **`loader.php`** — registers the new class
- **Tests** — covers rename, missing-header no-op, case-sensitivity, and `build()` factory
- **Docs** — `creating-middlewares.md` and `README.md` updated

## Usage

```php
[
    'class' => 'Tent\\Middlewares\\RenameHeaderMiddleware',
    'from'  => 'Host',
    'to'    => 'X-Original-Host'
]
```

Or directly:

```php
$middleware = RenameHeaderMiddleware::build(['from' => 'Host', 'to' => 'X-Original-Host']);
```

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `github.com (HTTP Only)`
>   - Triggering command: `/usr/bin/ssh /usr/bin/ssh -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack &#39;PHPCSStandards/PHP_CodeSniffer.git&#39;` (packet block)
>   - Triggering command: `/usr/bin/ssh /usr/bin/ssh -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack &#39;PHPCSStandards/composer-installer.git&#39;` (packet block)
>   - Triggering command: `/usr/bin/ssh /usr/bin/ssh -o SendEnv=GIT_PROTOCOL git@github.com git-upload-pack &#39;composer/pcre.git&#39;` (packet block)
> - `https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install 2wu4yx6pl9i` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install 2wu4yx6pl9i` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/Seldaek/monolog/zipball/37308608e599f34a1a4845b16440047ec98a172a`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install 2wu4yx6pl9i` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/a23a2bf4f31d3518f3ecb38660c95715dfead60f`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/jawira/plantuml-encoding/zipball/fe8bce2d7ff5bb5cccf374349999cef7d6246a32`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/jawira/plantuml/zipball/f53f0320125c2367ad4c202c27dbdbe6dcb064fa`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/nette/schema/zipball/086497a2f34b82fede9b5a41cc8e131d087cd8f7`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/nette/utils/zipball/f76b5dc3d6c6d3043c8d937df2698515b99cbaf5`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/parsica-php/parsica/zipball/e5b0a763e26e89de39a0790e949b8ff7f0909d73`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/FlyFinder/zipball/6e145e676d9fbade7527fd8d4c99ab36b687b958`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/GraphViz/zipball/115999dc7f31f2392645aa825a94a6b165e1cedf`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/Reflection/zipball/5e5db15b34e6eae755cb97beaa7fe076ae9e8d4c`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/filesystem/zipball/baf81ce5f6ebf450b798bee74f60d107c21e3a8b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/guides-core/zipball/7431c7cc32bd6d2ba52174c3ce86aac5a029711f`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/guides-graphs/zipball/85a7849dd982ca63a07a9086a1d9df8fd93c4c5d`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/guides-markdown/zipball/09678083f68a5630195b2378e65c7c9961e690d4`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/guides-restructured-text/zipball/25efd3eb618f63a5f48e4b37feaca2158b44680b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/json-path/zipball/f1b1cd2ce99c5be7ef576c516d3d476a2e2b6566`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpDocumentor/phpDocumentor/zipball/4d3daedcffb747791b212545da819bfc81252ea9`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/cache/zipball/5b088fa41eb9568748dc255c45e4054c387ba73b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/clock/zipball/9169f24776edde469914c1e7a1442a50f7a4e110`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/config/zipball/d445badf0ad2c2a492e38c0378c39997a56ef97b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/console/zipball/0bc2199c6c1f05276b05956f1ddc63f6d7eb5fc3`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/contracts/zipball/97a588e965e92e3f197085531cbe440d0fcf48c3`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/dependency-injection/zipball/b17882e933c4c606620247b6708ab53aa3b88753`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/dom-crawler/zipball/f57f1cbd6b13b54e7f8a25cae1ee55cbe892b1f3`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/dotenv/zipball/924edbc9631b75302def0258ed1697948b17baf6`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/event-dispatcher/zipball/99d7e101826e6610606b9433248f80c1997cd20b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/expression-language/zipball/89c10ef5ca65968ec7ce7ce033c7f36eeb1b0312`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/filesystem/zipball/441c6b69f7222aadae7cbf5df588496d5ee37789`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/finder/zipball/24965ca011dac87431729640feef8bcf7b5523e0`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/html-sanitizer/zipball/5b0bbcc3600030b535dd0b17a0e8c56243f96d7f`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/http-client/zipball/84bb634857a893cc146cceb467e31b3f02c5fe9f`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/property-access/zipball/fa49bf1ca8fce1ba0e2dba4e4658554cfb9364b1`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/property-info/zipball/1c9d326bd69602561e2ea467a16c09b5972eee21`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/routing/zipball/0dc6253e864e71b486e8ba4970a56ab849106ebe`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/stopwatch/zipball/b67e94e06a05d9572c2fa354483b3e13e3cb1898`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/string/zipball/50590a057841fa6bf69d12eceffce3465b9e32cb`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/type-info/zipball/f83c725e72b39b2704b9d6fc85070ad6ac7a5889`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/symfony/yaml/zipball/8207ae83da19ee3748d6d4f567b4d9a7c656e331`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/csv/zipball/6582ace29ae09ba5b07049d40ea13eb19c8b5073`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/flysystem/zipball/3239285c825c152bcc315fe0e87d6b55f5972ed1`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/tactician/zipball/93b2eafa4321f84164f3d3f607a32a953f3fff0b`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9`
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
> - `https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68`
>   - Triggering command: `/usr/local/bin/php php /usr/local/bin/composer install` (http block)
>   - Triggering command: `/usr/bin/php8.3 /usr/bin/php8.3 -n -c /tmp/wQTVdx /usr/bin/composer install --no-interaction DROP -nette-utils.gitdocker` (http block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/darthjee/tent/settings/copilot/coding_agent) (admins only)
>
> </details>
