### PR TITLE
Add photo upload to dev app frontend 

### DIFF
--- a/dev/frontend/assets/js/clients/PersonClient.js
+++ b/dev/frontend/assets/js/clients/PersonClient.js
@@ -1,4 +1,10 @@
 class PersonClient {
+  /**
+   * Fetches the list of all persons.
+   *
+   * @returns {Promise<Object[]>} Resolves with the array of person objects.
+   * @throws {Error} If the request fails.
+   */
   async list() {
     const response = await fetch('/persons');
     if (!response.ok) {
@@ -7,6 +13,13 @@ class PersonClient {
     return response.json();
   }
 
+  /**
+   * Creates a new person.
+   *
+   * @param {Object} data - The person attributes to create.
+   * @returns {Promise<Object>} Resolves with the created person object.
+   * @throws {Error} If the request fails.
+   */
   async create(data) {
     const response = await fetch('/persons', {
       method: 'POST',
@@ -15,6 +28,30 @@ class PersonClient {
     });
     if (!response.ok) {
       throw new Error('Failed to create person');
+    }
+    return response.json();
+  }
+
+  /**
+   * Uploads a photo for the given person.
+   *
+   * Sends a POST request to `/persons/:id/photo` with the file as
+   * `multipart/form-data` (field name `photo`).
+   *
+   * @param {number|string} id   - The ID of the person.
+   * @param {File}          file - The JPEG image file to upload.
+   * @returns {Promise<Object>} Resolves with the updated person object.
+   * @throws {Error} If the upload request fails.
+   */
+  async uploadPhoto(id, file) {
+    const formData = new FormData();
+    formData.append('photo', file);
+    const response = await fetch(`/persons/${id}/photo`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error('Failed to upload photo');
     }
     return response.json();
   }

--- a/dev/frontend/assets/js/components/PersonList.jsx
+++ b/dev/frontend/assets/js/components/PersonList.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PersonClient } from '../clients/PersonClient';
+import PersonPhotoForm from './PersonPhotoForm';
 
 const PersonList = () => {
   const [persons, setPersons] = useState([]);
@@ -28,6 +29,7 @@ const PersonList = () => {
         {persons.map((person) => (
           <li key={person.id}>
             {person.first_name} {person.last_name} ({person.birthdate})
+            <PersonPhotoForm personId={person.id} />
           </li>
         ))}
       </ul>

--- a/dev/frontend/assets/js/components/PersonPhotoForm.jsx
+++ b/dev/frontend/assets/js/components/PersonPhotoForm.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { PersonClient } from '../clients/PersonClient';
+
+/**
+ * Form component for uploading a photo for a specific person.
+ *
+ * Renders a JPEG file input and an "Upload Photo" button. While the upload
+ * is in progress the button is disabled and shows "Uploading…". On success
+ * it shows a brief confirmation message; on failure it shows the error text.
+ *
+ * @param {Object}        props          - Component props.
+ * @param {number|string} props.personId - The ID of the person whose photo
+ *                                         is being uploaded.
+ * @returns {JSX.Element} The rendered upload form.
+ */
+export default function PersonPhotoForm({ personId }) {
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  /**
+   * Updates the selected file in state and clears any previous
+   * success/error feedback.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} e - The file input change event.
+   */
+  const handleFileChange = (e) => {
+    setFile(e.target.files[0]);
+    setError(null);
+    setSuccess(false);
+  };
+
+  /**
+   * Submits the selected file to the server via {@link PersonClient#uploadPhoto}.
+   * Manages loading, success, and error states during the async operation.
+   *
+   * @param {React.FormEvent<HTMLFormElement>} e - The form submit event.
+   */
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      await (new PersonClient()).uploadPhoto(personId, file);
+      setSuccess(true);
+      setFile(null);
+      e.target.reset();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="d-flex align-items-center gap-2 mt-1">
+      <input
+        type="file"
+        accept="image/jpeg"
+        className="form-control form-control-sm"
+        onChange={handleFileChange}
+        required
+      />
+      <button
+        type="submit"
+        className="btn btn-sm btn-secondary"
+        disabled={loading || !file}
+      >
+        {loading ? 'Uploading...' : 'Upload Photo'}
+      </button>
+      {success && <span className="text-success small">Uploaded!</span>}
+      {error && <span className="text-danger small">{error}</span>}
+    </form>
+  );
+}

--- a/dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js
+++ b/dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js
@@ -1,0 +1,106 @@
+import { PersonClient } from '../../../assets/js/clients/PersonClient.js';
+
+describe('PersonClient', function() {
+  let client;
+
+  beforeEach(function() {
+    client = new PersonClient();
+  });
+
+  describe('uploadPhoto()', function() {
+    it('should upload a photo successfully', async function() {
+      const mockResponse = {
+        id: 1,
+        first_name: 'FirstName',
+        last_name: 'LastName',
+        birthdate: '1985-03-05',
+        created_at: '2026-01-11 21:59:45',
+        updated_at: '2026-01-11 21:59:45'
+      };
+
+      spyOn(global, 'fetch').and.returnValue(
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        })
+      );
+
+      const file = new File(['(binary)'], 'photo.jpg', { type: 'image/jpeg' });
+      const result = await client.uploadPhoto(1, file);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/persons/1/photo',
+        jasmine.objectContaining({ method: 'POST' })
+      );
+
+      const callArgs = global.fetch.calls.mostRecent().args;
+      const body = callArgs[1].body;
+      expect(body instanceof FormData).toBe(true);
+      expect(body.get('photo')).toBe(file);
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should throw error when upload fails', async function() {
+      spyOn(global, 'fetch').and.returnValue(
+        Promise.resolve({
+          ok: false,
+          status: 500
+        })
+      );
+
+      const file = new File(['(binary)'], 'photo.jpg', { type: 'image/jpeg' });
+
+      try {
+        await client.uploadPhoto(1, file);
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).toBe('Failed to upload photo');
+      }
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/persons/1/photo',
+        jasmine.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should throw error when fetch rejects', async function() {
+      const networkError = new Error('Network error');
+      spyOn(global, 'fetch').and.returnValue(
+        Promise.reject(networkError)
+      );
+
+      const file = new File(['(binary)'], 'photo.jpg', { type: 'image/jpeg' });
+
+      try {
+        await client.uploadPhoto(1, file);
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).toBe(networkError);
+      }
+    });
+
+    it('should handle 422 unprocessable entity', async function() {
+      spyOn(global, 'fetch').and.returnValue(
+        Promise.resolve({
+          ok: false,
+          status: 422
+        })
+      );
+
+      const file = new File(['(binary)'], 'photo.jpg', { type: 'image/jpeg' });
+
+      try {
+        await client.uploadPhoto(2, file);
+        fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error.message).toBe('Failed to upload photo');
+      }
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/persons/2/photo',
+        jasmine.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+});

--- a/docs/agents/dev-app.md
+++ b/docs/agents/dev-app.md
@@ -24,11 +24,12 @@ A self-contained PHP API server that mirrors the same class-loading pattern as T
 
 `dev/api/source/index.php` — configures the MySQL connection from environment variables, then registers routes:
 
-| Method | Path       | Endpoint class              |
-|--------|------------|-----------------------------|
-| GET    | `/health`  | `HealthCheckEndpoint`       |
-| GET    | `/persons` | `ListPersonsEndpoint`       |
-| POST   | `/persons` | `CreatePersonEndpoint`      |
+| Method | Path                       | Endpoint class                |
+|--------|----------------------------|-------------------------------|
+| GET    | `/health`                  | `HealthCheckEndpoint`         |
+| GET    | `/persons`                 | `ListPersonsEndpoint`         |
+| POST   | `/persons`                 | `CreatePersonEndpoint`        |
+| POST   | `/persons/:id/photo.json`  | `UploadPersonPhotoEndpoint`   |
 
 Routes are registered with `Configuration::add('METHOD', '/path', EndpointClass::class)`.
 

--- a/docs/agents/issues/193_add-photo-endpoint-dev-app-frontend.md
+++ b/docs/agents/issues/193_add-photo-endpoint-dev-app-frontend.md
@@ -1,17 +1,67 @@
 # Issue 193: Add Photo Endpoint for Dev App Frontend
 
 ## Description
-In the frontend of the dev app, we need an endpoint that allows uploading a photo to a person.
 
-## Endpoint
+Add photo upload support to the dev-app React frontend (`dev/frontend/`). The backend endpoint already exists (issue 192): `POST /persons/:id/photo.json`, which accepts `multipart/form-data` with a `photo` field (JPEG only) and returns the person JSON on success or `{ error }` on failure.
 
+## Scope
+
+This issue covers only the **frontend** (`dev/frontend/`). Do not touch `source/` (the Tent proxy).
+
+## What to implement
+
+### 1. `PersonClient.uploadPhoto(id, file)` — `dev/frontend/assets/js/clients/PersonClient.js`
+
+New method on the existing `PersonClient` class:
+
+```js
+async uploadPhoto(id, file) {
+  const formData = new FormData();
+  formData.append('photo', file);
+
+  const response = await fetch(`/persons/${id}/photo.json`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!response.ok) {
+    throw new Error('Failed to upload photo');
+  }
+  return response.json();
+}
 ```
-POST /persons/:id/photo
-```
 
-## Expected Behavior
-- The frontend route accepts a file upload and forwards it to the backend.
-- Returns an appropriate response on success or failure.
+Do **not** set `Content-Type` manually — the browser sets it with the correct `multipart/form-data` boundary.
 
----
-See issue for details: https://github.com/darthjee/tent/issues/193
+### 2. Spec for `uploadPhoto` — `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js`
+
+Follow the pattern of `PersonClientCreate_spec.js`. Cover:
+- Success: stub `fetch` as `ok: true`, verify URL (`/persons/1/photo.json`), method (`POST`), and return value.
+- Failure (non-ok response): verify `Error('Failed to upload photo')` is thrown.
+- Network error: verify the rejection propagates.
+
+### 3. `PersonPhotoForm` component — `dev/frontend/assets/js/components/PersonPhotoForm.jsx`
+
+New React component. Props: `personId`. Follow the same Bootstrap 5 + state pattern as `PersonForm.jsx`:
+- File input with `accept="image/jpeg"`.
+- Submit button (disabled while loading).
+- Inline success/error feedback via Bootstrap alert divs.
+- On submit, call `new PersonClient().uploadPhoto(personId, file)`.
+
+### 4. Integrate into `PersonList` — `dev/frontend/assets/js/components/PersonList.jsx`
+
+Render `<PersonPhotoForm personId={person.id} />` inside each `<li>` item.
+
+## Files to change
+
+| Action | File |
+|--------|------|
+| Modify | `dev/frontend/assets/js/clients/PersonClient.js` |
+| Create | `dev/frontend/assets/js/components/PersonPhotoForm.jsx` |
+| Modify | `dev/frontend/assets/js/components/PersonList.jsx` |
+| Create | `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js` |
+
+## Reference
+
+See the plan: `docs/agents/plans/193_add-photo-endpoint-dev-app-frontend/plan.md`
+
+See issue: https://github.com/darthjee/tent/issues/193

--- a/docs/agents/plans/193_add-photo-endpoint-dev-app-frontend/plan.md
+++ b/docs/agents/plans/193_add-photo-endpoint-dev-app-frontend/plan.md
@@ -13,11 +13,15 @@ The frontend follows these conventions:
 - UI components live in `dev/frontend/assets/js/components/`, using React 19 + Bootstrap 5.
 - Tests live in `dev/frontend/spec/`, mirroring the source structure, using Jasmine + `spyOn(global, 'fetch')`.
 
+**Do not touch `source/`** (the Tent proxy). This issue is scoped entirely to `dev/frontend/`.
+
 ## Implementation Steps
 
 ### Step 1 — Add `uploadPhoto(id, file)` to `PersonClient`
 
-Add a new method to `PersonClient.js`:
+File: `dev/frontend/assets/js/clients/PersonClient.js`
+
+Add the method inside the existing `PersonClient` class, after `create()`:
 
 ```js
 async uploadPhoto(id, file) {
@@ -35,39 +39,140 @@ async uploadPhoto(id, file) {
 }
 ```
 
-No `Content-Type` header is set manually — the browser sets it automatically with the correct boundary for `multipart/form-data`.
+Do **not** set a `Content-Type` header — the browser sets it automatically with the correct `multipart/form-data` boundary when `body` is a `FormData`.
 
 ### Step 2 — Write tests for `uploadPhoto`
 
-Create `spec/clients/PersonClient/PersonClientUploadPhoto_spec.js`, following the pattern of `PersonClientCreate_spec.js`:
+File: `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js`
 
-- success: stub `fetch` as `ok: true`, verify URL, method, and return value.
-- failure (non-ok response): verify that `Error('Failed to upload photo')` is thrown.
-- network error: verify that the rejection propagates.
+Follow the exact same structure as `PersonClientCreate_spec.js` (same `describe` nesting, same spy pattern). The `file` argument passed to `uploadPhoto` can be any value in tests — it is passed directly to `FormData.append`, and `fetch` is fully stubbed.
+
+Cases to cover:
+
+**Success:**
+```js
+spyOn(global, 'fetch').and.returnValue(
+  Promise.resolve({ ok: true, json: () => Promise.resolve(mockPersonData) })
+);
+const result = await client.uploadPhoto(1, mockFile);
+expect(global.fetch).toHaveBeenCalledWith(
+  '/persons/1/photo.json',
+  jasmine.objectContaining({ method: 'POST' })
+);
+expect(result).toEqual(mockPersonData);
+```
+
+**Failure (non-ok response, e.g. 422):**
+```js
+spyOn(global, 'fetch').and.returnValue(Promise.resolve({ ok: false, status: 422 }));
+// expect Error('Failed to upload photo') to be thrown
+```
+
+**Network error:**
+```js
+const networkError = new Error('Network error');
+spyOn(global, 'fetch').and.returnValue(Promise.reject(networkError));
+// expect the same networkError instance to propagate
+```
+
+> Note: verifying the exact `FormData` contents via `toHaveBeenCalledWith` is not straightforward in Jasmine (FormData instances are opaque). Verifying the URL and `method` is sufficient.
 
 ### Step 3 — Create `PersonPhotoForm` component
 
-Create `dev/frontend/assets/js/components/PersonPhotoForm.jsx`:
+File: `dev/frontend/assets/js/components/PersonPhotoForm.jsx`
 
-- Props: `personId`
-- State: `file`, `loading`, `error`, `success`
-- Renders a file input (`accept="image/jpeg"`) and a submit button.
-- On submit, calls `new PersonClient().uploadPhoto(personId, file)`.
-- Shows success/error feedback inline (same Bootstrap alert pattern as `PersonForm`).
+Props: `{ personId }`
+
+State:
+- `file` — the selected `File` object (or `null`)
+- `loading` — boolean
+- `error` — string or null
+- `success` — boolean
+
+Behaviour:
+- File input with `accept="image/jpeg"`. On change, update `file` state from `e.target.files[0]`.
+- Submit button disabled when `loading` is true or `file` is null.
+- On submit, call `new PersonClient().uploadPhoto(personId, file)`. On success set `success = true` and clear `file`. On error set `error = err.message`. Always clear `loading`.
+- Show a Bootstrap `alert-success` div when `success` is true and a `alert-danger` div when `error` is set (same pattern as `PersonForm.jsx`).
+
+Reference skeleton:
+
+```jsx
+import { useState } from 'react';
+import { PersonClient } from '../clients/PersonClient';
+
+export default function PersonPhotoForm({ personId }) {
+  const [file, setFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await new PersonClient().uploadPhoto(personId, file);
+      setSuccess(true);
+      setFile(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {error && <div className="alert alert-danger">{error}</div>}
+      {success && <div className="alert alert-success">Photo uploaded successfully!</div>}
+      <input
+        type="file"
+        accept="image/jpeg"
+        onChange={(e) => setFile(e.target.files[0])}
+      />
+      <button type="submit" disabled={loading || !file}>
+        {loading ? 'Uploading...' : 'Upload Photo'}
+      </button>
+    </form>
+  );
+}
+```
 
 ### Step 4 — Integrate into `PersonList`
 
-In `PersonList.jsx`, render `<PersonPhotoForm personId={person.id} />` inside each `<li>` for every person in the list.
+File: `dev/frontend/assets/js/components/PersonList.jsx`
+
+Import `PersonPhotoForm` and render it inside each list item:
+
+```jsx
+import PersonPhotoForm from './PersonPhotoForm';
+
+// inside the map:
+<li key={person.id}>
+  {person.first_name} {person.last_name} ({person.birthdate})
+  <PersonPhotoForm personId={person.id} />
+</li>
+```
 
 ## Files to Change
 
-- `dev/frontend/assets/js/clients/PersonClient.js` — add `uploadPhoto(id, file)` method
-- `dev/frontend/assets/js/components/PersonPhotoForm.jsx` — new component (create)
-- `dev/frontend/assets/js/components/PersonList.jsx` — render `PersonPhotoForm` per person
-- `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js` — new spec file (create)
+| Action | File |
+|--------|------|
+| Modify | `dev/frontend/assets/js/clients/PersonClient.js` |
+| Create | `dev/frontend/assets/js/components/PersonPhotoForm.jsx` |
+| Modify | `dev/frontend/assets/js/components/PersonList.jsx` |
+| Create | `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js` |
+
+## Commit order
+
+1. `PersonClient.uploadPhoto` + its spec (client logic and tests together)
+2. `PersonPhotoForm` + integration in `PersonList` (UI changes together)
 
 ## Notes
 
-- No `Content-Type` header should be set manually on the `fetch` call; omitting it lets the browser add the correct `multipart/form-data` boundary.
-- The backend only accepts `image/jpeg`; the file input should use `accept="image/jpeg"` to guide the user, though validation still happens on the backend.
+- Do **not** set `Content-Type` manually on the `fetch` call.
+- The backend only accepts `image/jpeg`; use `accept="image/jpeg"` on the input to guide the user.
 - No component-level Jasmine specs are planned (consistent with existing components which have no specs).
+- The mock person data shape for tests: `{ id, first_name, last_name, birthdate, created_at, updated_at }` — see existing specs for reference values.

--- a/docs/agents/plans/193_add-photo-endpoint-dev-app-frontend/plan.md
+++ b/docs/agents/plans/193_add-photo-endpoint-dev-app-frontend/plan.md
@@ -1,149 +1,73 @@
-# Plan: Issue 193 — Add Photo Endpoint for Dev App Frontend (Tent proxy)
+# Plan: Add Photo Endpoint for Dev App Frontend
 
-## Goal
+## Overview
 
-Expose `POST /persons/:id/photo` through the Tent proxy so that browser clients can upload a person's photo without knowing the backend URL convention.
-Tent must forward the request to `api_dev` at `POST /persons/:id/photo.json` (issue 192).
-
----
+Add photo upload support to the dev-app React frontend: a new `PersonClient.uploadPhoto()` method and a `PersonPhotoForm` component rendered per person in `PersonList`.
 
 ## Context
 
-- Tent routes are defined in `docker_volumes/configuration/configure.php` (or `rules/`), which is **not version-controlled**. The plan documents the required configuration and any new Tent classes that need to be shipped in the source.
-- Available matchers today: `ExactRequestMatcher`, `BeginsWithRequestMatcher`, `EndsWithRequestMatcher`, `RequestMethodMatcher`, `NegativeMatcher`. None supports arbitrary URI patterns.
-- `SetPathMiddleware` sets a **static** path — it cannot append a dynamic suffix.
-- The frontend path (`/persons/:id/photo`) and the backend path (`/persons/:id/photo.json`) differ only by the `.json` suffix, so the proxy must append `.json` to the path before forwarding.
+The backend already exposes `POST /persons/:id/photo.json` (implemented in issue 192). It accepts a `multipart/form-data` request with a `photo` field (JPEG only) and returns the person JSON on success (200) or `{ error }` on failure (400, 404, 422, 500).
 
----
+The frontend follows these conventions:
+- HTTP logic lives in `dev/frontend/assets/js/clients/PersonClient.js` (plain `fetch`, no framework).
+- UI components live in `dev/frontend/assets/js/components/`, using React 19 + Bootstrap 5.
+- Tests live in `dev/frontend/spec/`, mirroring the source structure, using Jasmine + `spyOn(global, 'fetch')`.
 
 ## Implementation Steps
 
-### Step 1 — New middleware: `AppendSuffixToPathMiddleware`
+### Step 1 — Add `uploadPhoto(id, file)` to `PersonClient`
 
-**File:** `source/source/lib/middlewares/AppendSuffixToPathMiddleware.php`
+Add a new method to `PersonClient.js`:
 
-A request-phase middleware that appends a fixed string to the current request path:
+```js
+async uploadPhoto(id, file) {
+  const formData = new FormData();
+  formData.append('photo', file);
 
-```php
-public function processRequest(ProcessingRequest $request): ProcessingRequest
-{
-    $request->setRequestPath($request->requestPath() . $this->suffix);
-    return $request;
+  const response = await fetch(`/persons/${id}/photo.json`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!response.ok) {
+    throw new Error('Failed to upload photo');
+  }
+  return response.json();
 }
 ```
 
-Configuration key: `suffix` (string).
-Factory method `build(array $attributes)` reads `$attributes['suffix']`.
+No `Content-Type` header is set manually — the browser sets it automatically with the correct boundary for `multipart/form-data`.
 
-Usage in configuration:
+### Step 2 — Write tests for `uploadPhoto`
 
-```php
-[
-    'class'  => 'Tent\\Middlewares\\AppendSuffixToPathMiddleware',
-    'suffix' => '.json',
-]
-```
+Create `spec/clients/PersonClient/PersonClientUploadPhoto_spec.js`, following the pattern of `PersonClientCreate_spec.js`:
 
----
+- success: stub `fetch` as `ok: true`, verify URL, method, and return value.
+- failure (non-ok response): verify that `Error('Failed to upload photo')` is thrown.
+- network error: verify that the rejection propagates.
 
-### Step 2 — Register the new middleware class
+### Step 3 — Create `PersonPhotoForm` component
 
-**File:** `source/source/loader.php`
+Create `dev/frontend/assets/js/components/PersonPhotoForm.jsx`:
 
-Add after existing middleware requires:
+- Props: `personId`
+- State: `file`, `loading`, `error`, `success`
+- Renders a file input (`accept="image/jpeg"`) and a submit button.
+- On submit, calls `new PersonClient().uploadPhoto(personId, file)`.
+- Shows success/error feedback inline (same Bootstrap alert pattern as `PersonForm`).
 
-```php
-require_once __DIR__ . '/lib/middlewares/AppendSuffixToPathMiddleware.php';
-```
+### Step 4 — Integrate into `PersonList`
 
----
+In `PersonList.jsx`, render `<PersonPhotoForm personId={person.id} />` inside each `<li>` for every person in the list.
 
-### Step 3 — Wire the middleware in the factory
+## Files to Change
 
-**File:** (wherever Tent resolves middleware class names to `build()` calls — locate the middleware factory/builder used in `Configuration::buildRule()`)
-
-Add a case for `AppendSuffixToPathMiddleware` so it is instantiated with `AppendSuffixToPathMiddleware::build($attrs)`.
-
----
-
-### Step 4 — Tent proxy rule (configuration documentation)
-
-The rule below belongs in `docker_volumes/configuration/configure.php` (or a dedicated file under `docker_volumes/configuration/rules/`). Because this directory is not version-controlled, the canonical configuration must be documented here so operators can reproduce it.
-
-```php
-Configuration::buildRule([
-    'handler' => [
-        'type' => 'default_proxy',
-        'host' => 'http://api:80',
-    ],
-    'matchers' => [
-        ['type' => 'begins_with', 'uri' => '/persons/'],
-        ['type' => 'ends_with',   'uri' => '/photo'],
-        ['method' => 'POST'],
-    ],
-    'middlewares' => [
-        [
-            'class'  => 'Tent\\Middlewares\\AppendSuffixToPathMiddleware',
-            'suffix' => '.json',
-        ],
-    ],
-]);
-```
-
-**Matcher combination rationale:**
-- `BeginsWithRequestMatcher('/persons/')` ensures only person sub-routes are matched.
-- `EndsWithRequestMatcher('/photo')` restricts to the upload path (not `/photo.json`, not other sub-paths).
-- `RequestMethodMatcher('POST')` prevents accidental GET/PUT matches.
-
-The combination is an approximation of the pattern `/persons/\d+/photo`. It would also match a (hypothetical) path like `/persons/foo/bar/photo` — acceptable for now given the controlled scope of the dev application. A future `RegexRequestMatcher` (see notes below) would be more precise.
-
----
-
-### Step 5 — Tests
-
-#### 5a — `AppendSuffixToPathMiddleware` unit test
-
-**File:** `source/tests/unit/lib/middlewares/AppendSuffixToPathMiddlewareTest.php`
-
-Cases:
-- Appends suffix to a plain path (`/persons/1/photo` → `/persons/1/photo.json`).
-- Appends suffix when path already has a trailing segment.
-- Empty suffix leaves path unchanged.
-- Does not modify response (response-phase no-op).
-
-#### 5b — Integration test (optional, within existing integration test suite)
-
-Verify that a `POST /persons/1/photo` request routed through Tent reaches `api_dev` as `POST /persons/1/photo.json`. Uses the dev API in the test environment.
-
----
+- `dev/frontend/assets/js/clients/PersonClient.js` — add `uploadPhoto(id, file)` method
+- `dev/frontend/assets/js/components/PersonPhotoForm.jsx` — new component (create)
+- `dev/frontend/assets/js/components/PersonList.jsx` — render `PersonPhotoForm` per person
+- `dev/frontend/spec/clients/PersonClient/PersonClientUploadPhoto_spec.js` — new spec file (create)
 
 ## Notes
 
-### Future improvement: `RegexRequestMatcher`
-
-The `begins_with` + `ends_with` matcher combination is pragmatic but imprecise. A dedicated `RegexRequestMatcher` would let operators write:
-
-```php
-['type' => 'regex', 'pattern' => '^/persons/\d+/photo$', 'method' => 'POST']
-```
-
-This is intentionally left out of scope for this issue. If needed, it should be a separate issue targeting the matcher system.
-
----
-
-## Files Changed / Created
-
-| Action | Path |
-|--------|------|
-| Create | `source/source/lib/middlewares/AppendSuffixToPathMiddleware.php` |
-| Modify | `source/source/loader.php` |
-| Modify | middleware factory (locate exact file) |
-| Create | `source/tests/unit/lib/middlewares/AppendSuffixToPathMiddlewareTest.php` |
-| Document | `docker_volumes/configuration/configure.php` (not version-controlled) |
-
----
-
-## Commit order
-
-1. `AppendSuffixToPathMiddleware` — new middleware + loader + factory + unit test
-2. Configuration documentation update (plan file) if needed
+- No `Content-Type` header should be set manually on the `fetch` call; omitting it lets the browser add the correct `multipart/form-data` boundary.
+- The backend only accepts `image/jpeg`; the file input should use `accept="image/jpeg"` to guide the user, though validation still happens on the backend.
+- No component-level Jasmine specs are planned (consistent with existing components which have no specs).


### PR DESCRIPTION
Adds photo upload functionality to the dev app frontend so browser clients can upload a person's photo.

## Changes Made

- **`PersonClient.uploadPhoto(id, file)`**: New method that sends `POST /persons/:id/photo` with `multipart/form-data` (field `photo`)
- **`PersonPhotoForm.jsx`**: New React component with a JPEG file input and upload button, including loading/success/error feedback
- **`PersonList.jsx`**: Integrates `PersonPhotoForm` inline for each person in the list
- **`PersonClientUploadPhoto_spec.js`**: Jasmine tests covering successful upload, HTTP error, network rejection, and 422 unprocessable entity