### PR TITLE
Improve 404 debug fallback logging

### DIFF
--- a/source/source/lib/request_handlers/MissingRequestHandler.php
+++ b/source/source/lib/request_handlers/MissingRequestHandler.php
@@ -2,6 +2,7 @@
 
 namespace Tent\RequestHandlers;
 
+use Tent\Log\Logger;
 use Tent\Models\RequestInterface;
 use Tent\Models\Response;
 use Tent\Models\MissingResponse;
@@ -22,6 +23,11 @@ class MissingRequestHandler extends RequestHandler
      */
     protected function processsRequest(RequestInterface $request): Response
     {
+        Logger::debug(
+            '[404] - no rules matched — method: ' . $request->requestMethod() .
+            ', uri: ' . $request->requestPath()
+        );
+
         return new MissingResponse($request);
     }
 }

--- a/source/source/lib/service/RequestProcessor.php
+++ b/source/source/lib/service/RequestProcessor.php
@@ -5,7 +5,6 @@ namespace Tent\Service;
 use Tent\RequestHandlers\MissingRequestHandler;
 use Tent\RequestHandlers\RequestHandler;
 use Tent\Configuration;
-use Tent\Log\Logger;
 use Tent\Models\Request;
 use Tent\Models\ProcessingRequest;
 use Tent\Models\Response;
@@ -76,11 +75,6 @@ class RequestProcessor
                 return $rule->handler();
             }
         }
-
-        Logger::debug(
-            '[404] - no rules matched — method: ' . $this->request->requestMethod() .
-            ', uri: ' . $this->request->requestPath()
-        );
 
         return new MissingRequestHandler();
     }

--- a/source/tests/unit/lib/request_handlers/MissingRequestHandler/MissingRequestHandlerTest.php
+++ b/source/tests/unit/lib/request_handlers/MissingRequestHandler/MissingRequestHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tent\Tests\RequestHandlers\MissingRequestHandler;
+
+require_once __DIR__ . '/../../../../support/loader.php';
+
+use PHPUnit\Framework\TestCase;
+use Tent\Log\Logger;
+use Tent\Log\LoggerInstance;
+use Tent\Models\ProcessingRequest;
+use Tent\RequestHandlers\MissingRequestHandler;
+use Tent\Models\Request;
+
+class MissingRequestHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Logger::setInstance(new LoggerInstance());
+    }
+
+    public function testReturns404AndLogsWhy(): void
+    {
+        $instance = $this->createMock(LoggerInstance::class);
+        $instance->expects($this->once())
+            ->method('log')
+            ->with('[404] - no rules matched — method: GET, uri: /missing', 'debug');
+        Logger::setInstance($instance);
+
+        $handler = new MissingRequestHandler();
+        $request = new Request([
+            'requestMethod' => 'GET',
+            'requestPath' => '/missing'
+        ]);
+        $response = $handler->handleRequest(new ProcessingRequest(['request' => $request]));
+
+        $this->assertEquals(404, $response->httpCode());
+    }
+}


### PR DESCRIPTION
## Summary
Improve development-level visibility for 404 responses by making the fallback path logging explicit and centralized.

## Changes
- Move unmatched-route 404 debug logging to `MissingRequestHandler` (fallback handler)
- Remove redundant unmatched-route debug log from `RequestProcessor`
- Add unit test coverage for `MissingRequestHandler` to validate 404 debug log emission

## Validation
- ✅ PHP syntax check on changed files
- ⚠️ Docker Compose lint/tests could not run in this environment due compose/image constraints (`darthjee/dev_tent` pull denied and `source/dockerfiles` path resolution failure)
- ✅ Parallel validation executed (Code Review + CodeQL)

## Issue
Closes #211