### PR TITLE
Publish `source/source` release archive as a GitHub Release asset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create release package
+          command: ./scripts/upload_release_package.sh build
+      - run:
           name: Docker build
           command: |
             TAG=${CIRCLE_TAG:-latest}
@@ -230,6 +233,9 @@ jobs:
       - run:
           name: Docker release
           command: docker push darthjee/tent:latest
+      - run:
+          name: Upload release package
+          command: ./scripts/upload_release_package.sh release
   update-description:
     docker:
       - image: darthjee/scripts:0.6.0

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Tent uses Apache with PHP to process all incoming requests through a centralized
 
 Tent is available as a Docker image: `darthjee/tent`
 
+## Release Package
+
+GitHub Releases also include a downloadable package named `tent-<tag>-source.tar.gz`.
+
+- The archive contains the exact contents of `source/source`.
+- Download the package from the release page for your version: https://github.com/darthjee/tent/releases
+- Extract it with `tar -xzf tent-<tag>-source.tar.gz` and place the extracted files where you want to run Tent source code.
+
+You can choose either distribution method:
+- Use the Docker image (`darthjee/tent`) for containerized deployments.
+- Use the release package when you want the raw source files from `source/source`.
+
 ## Current Status
 
 Tent is in active development. Currently implemented:

--- a/scripts/upload_release_package.sh
+++ b/scripts/upload_release_package.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/upload_release_package.sh <build|release|help>
+EOF
+}
+
+build_release_package() {
+  if [ -z "${CIRCLE_TAG:-}" ]; then
+    echo "Skipping package creation for non-tag build"
+    return 0
+  fi
+
+  RELEASE_PACKAGE="tent-${CIRCLE_TAG}-source.tar.gz"
+  tar -czf "$RELEASE_PACKAGE" -C source/source .
+
+  if [ -n "${BASH_ENV:-}" ]; then
+    echo "RELEASE_PACKAGE=$RELEASE_PACKAGE" >> "$BASH_ENV"
+  fi
+}
+
+upload_release_package() {
+  if [ -z "${CIRCLE_TAG:-}" ]; then
+    echo "Skipping release package upload for non-tag build"
+    return 0
+  fi
+
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "GITHUB_TOKEN is required to upload release assets"
+    exit 1
+  fi
+
+  if [ -z "${RELEASE_PACKAGE:-}" ]; then
+    RELEASE_PACKAGE="tent-${CIRCLE_TAG}-source.tar.gz"
+  fi
+
+  RELEASE_RESPONSE=$(curl --silent --show-error \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -w '\n%{http_code}' \
+    "https://api.github.com/repos/darthjee/tent/releases/tags/${CIRCLE_TAG}")
+  RELEASE_STATUS=$(echo "$RELEASE_RESPONSE" | tail -n 1)
+  RELEASE_DATA=$(echo "$RELEASE_RESPONSE" | sed '$d')
+
+  if [ "$RELEASE_STATUS" = "404" ]; then
+    RELEASE_PAYLOAD=$(python3 - <<'PY'
+import json
+import os
+
+tag = os.environ["CIRCLE_TAG"]
+print(json.dumps({
+    "tag_name": tag,
+    "name": tag,
+    "generate_release_notes": True
+}))
+PY
+)
+    RELEASE_DATA=$(curl --silent --show-error --fail \
+      -X POST \
+      -u "x-access-token:${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -d "$RELEASE_PAYLOAD" \
+      "https://api.github.com/repos/darthjee/tent/releases")
+  elif [ "$RELEASE_STATUS" != "200" ]; then
+    echo "Failed to fetch release for tag ${CIRCLE_TAG} (HTTP ${RELEASE_STATUS})"
+    echo "$RELEASE_DATA"
+    exit 1
+  fi
+
+  if [ -z "$RELEASE_DATA" ]; then
+    echo "Release data is empty for tag ${CIRCLE_TAG}"
+    exit 1
+  fi
+
+  RELEASE_ID=$(RELEASE_DATA="$RELEASE_DATA" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_DATA"])
+print(data["id"])
+PY
+)
+  UPLOAD_URL=$(RELEASE_DATA="$RELEASE_DATA" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_DATA"])
+print(data["upload_url"].split("{")[0])
+PY
+)
+
+  ASSETS_DATA=$(curl --silent --show-error --fail \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/darthjee/tent/releases/${RELEASE_ID}/assets")
+
+  EXISTING_ASSET_ID=$(RELEASE_PACKAGE="$RELEASE_PACKAGE" ASSETS_DATA="$ASSETS_DATA" python3 - <<'PY'
+import json
+import os
+
+name = os.environ["RELEASE_PACKAGE"]
+for asset in json.loads(os.environ["ASSETS_DATA"]):
+    if asset.get("name") == name:
+        print(asset["id"])
+        break
+PY
+)
+
+  if [ -n "$EXISTING_ASSET_ID" ]; then
+    curl --silent --show-error --fail \
+      -X DELETE \
+      -u "x-access-token:${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/darthjee/tent/releases/assets/${EXISTING_ASSET_ID}"
+  fi
+
+  curl --silent --show-error --fail \
+    -X POST \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Content-Type: application/gzip" \
+    --data-binary @"${RELEASE_PACKAGE}" \
+    "${UPLOAD_URL}?name=${RELEASE_PACKAGE}"
+}
+
+COMMAND="${1:-help}"
+case "$COMMAND" in
+  build)
+    build_release_package
+    ;;
+  release)
+    upload_release_package
+    ;;
+  help)
+    show_help
+    ;;
+  *)
+    echo "Invalid command: $COMMAND" >&2
+    show_help >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This PR extends the release pipeline to publish a downloadable source package on GitHub Releases while preserving the existing Docker image publish flow. The package is built explicitly from `source/source` so users can choose container or source-based distribution per release.

- **Release workflow: package generation**
  - Added a release step in `build-and-release` to create `tent-<tag>-source.tar.gz` from the contents of `source/source` (tag builds only).
  - Archive name is tag-aligned for predictable versioned artifacts.

- **Release workflow: GitHub Release asset publishing**
  - Added logic to fetch the Release by tag, create it when missing, and upload the archive as an asset.
  - Handles reruns by deleting an existing asset with the same name before upload.
  - Uses authenticated GitHub API calls with `GITHUB_TOKEN`.

- **Documentation: distribution options**
  - Updated `README.md` to document both delivery paths:
    - Docker image (`darthjee/tent`)
    - GitHub Release archive (`tent-<tag>-source.tar.gz`)
  - Clarified that the archive contains the files from `source/source` and included extraction guidance.

```yaml
- run:
    name: Create release package
    command: |
      RELEASE_PACKAGE="tent-${CIRCLE_TAG}-source.tar.gz"
      tar -czf "$RELEASE_PACKAGE" -C source/source .
```

Fixes #161