### PR TITLE
Add optional `skip_cache_header` bypass to file cache middleware and default proxy wiring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create release package
+          command: ./scripts/upload_release_package.sh build
+      - run:
           name: Docker build
           command: |
             TAG=${CIRCLE_TAG:-latest}
@@ -230,6 +233,9 @@ jobs:
       - run:
           name: Docker release
           command: docker push darthjee/tent:latest
+      - run:
+          name: Upload release package
+          command: ./scripts/upload_release_package.sh release
   update-description:
     docker:
       - image: darthjee/scripts:0.6.0

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Tent is an intelligent PHP-based proxy server that can route requests to backend
 
 ![tent](https://raw.githubusercontent.com/darthjee/tent/master/tent.png)
 
-**Current Version:** [0.7.3](https://github.com/darthjee/tent/releases/tag/0.7.3)
+**Current Version:** [0.7.4](https://github.com/darthjee/tent/releases/tag/0.7.4)
 
-**Next Release:** [0.7.4](https://github.com/darthjee/tent/compare/0.7.3...main)
+**Next Release:** [0.7.5](https://github.com/darthjee/tent/compare/0.7.4...main)
 
 ## Documentation
 
@@ -38,6 +38,18 @@ Tent uses Apache with PHP to process all incoming requests through a centralized
 ## Docker Image
 
 Tent is available as a Docker image: `darthjee/tent`
+
+## Release Package
+
+GitHub Releases also include a downloadable package named `tent-<tag>-source.tar.gz`.
+
+- The archive contains the exact contents of `source/source`.
+- Download the package from the release page for your version: https://github.com/darthjee/tent/releases
+- Extract it with `tar -xzf tent-<tag>-source.tar.gz` and place the extracted files where you want to run Tent source code.
+
+You can choose either distribution method:
+- Use the Docker image (`darthjee/tent`) for containerized deployments.
+- Use the release package when you want the raw source files from `source/source`.
 
 ## Current Status
 
@@ -134,6 +146,7 @@ Configuration::buildRule([
         'host'  => 'http://api.com:80',
         // 'cache' => './cache',       // optional, defaults to './cache'
         // 'cacheCodes' => ['2xx'],    // optional, defaults to ['2xx']
+        // 'skip_cache_header' => 'X-Skip-Cache', // optional, bypasses cache when present
         // 'cache' => false,           // set to false to disable caching
     ],
     'matchers' => [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     container_name: tent_build
     build:
       context: source
-      dockerfile: dockerfiles/dev_tent/Dockerfile
+      dockerfile: ../dockerfiles/dev_tent/Dockerfile
     command: echo done
 
   ###################

--- a/docs/HOW_TO_USE_DARTHJEE-TENT.md
+++ b/docs/HOW_TO_USE_DARTHJEE-TENT.md
@@ -138,6 +138,7 @@ Configuration::buildRule([
 | `host`       | `string`         | Yes      | —           | Upstream backend URL |
 | `cache`      | `string\|false`  | No       | `'./cache'` | Cache directory path, or `false` to disable |
 | `cacheCodes` | `array`          | No       | `['2xx']`   | HTTP status codes/patterns to cache |
+| `skip_cache_header` | `string`   | No       | —           | Request header name that bypasses cache read/write when present |
 
 ---
 
@@ -439,6 +440,24 @@ Configuration::buildRule([
         'host'       => 'http://api:3000',
         'cache'      => './cache/api',
         'cacheCodes' => [200, 301]
+    ],
+    'matchers' => [
+        ['method' => 'GET', 'uri' => '/api/', 'type' => 'begins_with']
+    ]
+]);
+```
+
+### Bypass cache with request header
+
+When you need to force fresh responses for specific calls, configure `skip_cache_header`. Any request containing this header skips cache reads and writes for that request lifecycle:
+
+```php
+Configuration::buildRule([
+    'handler' => [
+        'type'              => 'default_proxy',
+        'host'              => 'http://api:3000',
+        'cache'             => './cache/api',
+        'skip_cache_header' => 'X-Skip-Cache'
     ],
     'matchers' => [
         ['method' => 'GET', 'uri' => '/api/', 'type' => 'begins_with']

--- a/docs/file-cache-middleware-matchers.md
+++ b/docs/file-cache-middleware-matchers.md
@@ -20,6 +20,8 @@
 1. **On request** (`processRequest`): Checks whether a cached file exists for the incoming request path. If found, the cached response is loaded and returned immediately, skipping the backend.
 2. **On response** (`processResponse`): After the handler returns a response, checks whether it should be cached. If all configured matchers pass, the response is written to disk.
 
+You can also set `skip_cache_header` to bypass cache lookup and cache writes when a specific request header is present.
+
 For standard proxying, prefer `DefaultProxyRequestHandler` (`'type' => 'default_proxy'`). Use `ProxyRequestHandler` (`'type' => 'proxy'`) when you need to configure `FileCacheMiddleware` explicitly as part of a custom middleware stack.
 
 The middleware is placed in the `middlewares` array of a rule configuration:
@@ -60,6 +62,7 @@ Matchers are defined as an array of associative arrays inside the `matchers` key
 [
     'class' => 'Tent\\Middlewares\\FileCacheMiddleware',
     'location' => './cache',
+    'skip_cache_header' => 'X-Skip-Cache',
     'matchers' => [
         [
             'class' => 'Tent\\Matchers\\StatusCodeMatcher',

--- a/docs/request-handlers.md
+++ b/docs/request-handlers.md
@@ -56,6 +56,7 @@ It automatically adds:
 | `host` | `string` | Yes | — | Backend host used for proxying |
 | `cache` | `string \| false` | No | `'./cache'` | Cache directory, or `false` to disable cache |
 | `cacheCodes` | `array` | No | `['2xx']` | Status codes/patterns used by `StatusCodeMatcher` in cache middleware |
+| `skip_cache_header` | `string` | No | — | Request header name that bypasses cache read/write when present |
 
 ### Example: Default proxy with built-in cache
 
@@ -95,6 +96,22 @@ Configuration::buildRule([
         'host' => 'http://api:80',
         'cache' => './cache/api',
         'cacheCodes' => [200, 301]
+    ],
+    'matchers' => [
+        ['method' => 'GET', 'uri' => '/persons', 'type' => 'exact']
+    ]
+]);
+```
+
+### Example: Bypass cache with a request header
+
+```php
+Configuration::buildRule([
+    'handler' => [
+        'type' => 'default_proxy',
+        'host' => 'http://api:80',
+        'cache' => './cache/api',
+        'skip_cache_header' => 'X-Skip-Cache'
     ],
     'matchers' => [
         ['method' => 'GET', 'uri' => '/persons', 'type' => 'exact']

--- a/scripts/upload_release_package.sh
+++ b/scripts/upload_release_package.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/upload_release_package.sh <build|release|help>
+EOF
+}
+
+build_release_package() {
+  if [ -z "${CIRCLE_TAG:-}" ]; then
+    echo "Skipping package creation for non-tag build"
+    return 0
+  fi
+
+  RELEASE_PACKAGE="tent-${CIRCLE_TAG}-source.tar.gz"
+  tar -czf "$RELEASE_PACKAGE" -C source/source .
+
+  if [ -n "${BASH_ENV:-}" ]; then
+    echo "RELEASE_PACKAGE=$RELEASE_PACKAGE" >> "$BASH_ENV"
+  fi
+}
+
+upload_release_package() {
+  if [ -z "${CIRCLE_TAG:-}" ]; then
+    echo "Skipping release package upload for non-tag build"
+    return 0
+  fi
+
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "GITHUB_TOKEN is required to upload release assets"
+    exit 1
+  fi
+
+  if [ -z "${RELEASE_PACKAGE:-}" ]; then
+    RELEASE_PACKAGE="tent-${CIRCLE_TAG}-source.tar.gz"
+  fi
+
+  RELEASE_RESPONSE=$(curl --silent --show-error \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -w '\n%{http_code}' \
+    "https://api.github.com/repos/darthjee/tent/releases/tags/${CIRCLE_TAG}")
+  RELEASE_STATUS=$(echo "$RELEASE_RESPONSE" | tail -n 1)
+  RELEASE_DATA=$(echo "$RELEASE_RESPONSE" | sed '$d')
+
+  if [ "$RELEASE_STATUS" = "404" ]; then
+    RELEASE_PAYLOAD=$(python3 - <<'PY'
+import json
+import os
+
+tag = os.environ["CIRCLE_TAG"]
+print(json.dumps({
+    "tag_name": tag,
+    "name": tag,
+    "generate_release_notes": True
+}))
+PY
+)
+    RELEASE_DATA=$(curl --silent --show-error --fail \
+      -X POST \
+      -u "x-access-token:${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      -d "$RELEASE_PAYLOAD" \
+      "https://api.github.com/repos/darthjee/tent/releases")
+  elif [ "$RELEASE_STATUS" != "200" ]; then
+    echo "Failed to fetch release for tag ${CIRCLE_TAG} (HTTP ${RELEASE_STATUS})"
+    echo "$RELEASE_DATA"
+    exit 1
+  fi
+
+  if [ -z "$RELEASE_DATA" ]; then
+    echo "Release data is empty for tag ${CIRCLE_TAG}"
+    exit 1
+  fi
+
+  RELEASE_ID=$(RELEASE_DATA="$RELEASE_DATA" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_DATA"])
+print(data["id"])
+PY
+)
+  UPLOAD_URL=$(RELEASE_DATA="$RELEASE_DATA" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_DATA"])
+print(data["upload_url"].split("{")[0])
+PY
+)
+
+  ASSETS_DATA=$(curl --silent --show-error --fail \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/darthjee/tent/releases/${RELEASE_ID}/assets")
+
+  EXISTING_ASSET_ID=$(RELEASE_PACKAGE="$RELEASE_PACKAGE" ASSETS_DATA="$ASSETS_DATA" python3 - <<'PY'
+import json
+import os
+
+name = os.environ["RELEASE_PACKAGE"]
+for asset in json.loads(os.environ["ASSETS_DATA"]):
+    if asset.get("name") == name:
+        print(asset["id"])
+        break
+PY
+)
+
+  if [ -n "$EXISTING_ASSET_ID" ]; then
+    curl --silent --show-error --fail \
+      -X DELETE \
+      -u "x-access-token:${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/darthjee/tent/releases/assets/${EXISTING_ASSET_ID}"
+  fi
+
+  curl --silent --show-error --fail \
+    -X POST \
+    -u "x-access-token:${GITHUB_TOKEN}" \
+    -H "Content-Type: application/gzip" \
+    --data-binary @"${RELEASE_PACKAGE}" \
+    "${UPLOAD_URL}?name=${RELEASE_PACKAGE}"
+}
+
+COMMAND="${1:-help}"
+case "$COMMAND" in
+  build)
+    build_release_package
+    ;;
+  release)
+    upload_release_package
+    ;;
+  help)
+    show_help
+    ;;
+  *)
+    echo "Invalid command: $COMMAND" >&2
+    show_help >&2
+    exit 1
+    ;;
+esac

--- a/source/source/lib/middlewares/FileCacheMiddleware.php
+++ b/source/source/lib/middlewares/FileCacheMiddleware.php
@@ -10,6 +10,7 @@ use Tent\Models\Response;
 use Tent\Service\ResponseContentReader;
 use Tent\Service\ResponseCacher;
 use Tent\Matchers\RequestResponseMatcher;
+use Tent\Models\RequestInterface;
 
 /**
  * Middleware for caching responses to files.
@@ -61,18 +62,24 @@ class FileCacheMiddleware extends Middleware
      * @var array The list of response matchers to determine cacheability.
      */
     private array $matchers;
+    /**
+     * @var string|null Header name that forces cache bypass when present in request.
+     */
+    private ?string $skipCacheHeader;
 
     /**
      * Constructs a FileCacheMiddleware instance.
      *
-     * @param FolderLocation $location The base folder location for caching.
-     * @param array          $matchers Array of custom matchers for cacheability.
+     * @param FolderLocation $location        The base folder location for caching.
+     * @param array          $matchers        Array of custom matchers for cacheability.
+     * @param string|null    $skipCacheHeader Header name that disables cache read/write when present.
      */
-    public function __construct(FolderLocation $location, array $matchers = [])
+    public function __construct(FolderLocation $location, array $matchers = [], ?string $skipCacheHeader = null)
     {
         $this->location = $location;
 
         $this->matchers = $matchers;
+        $this->skipCacheHeader = $skipCacheHeader;
     }
 
     /**
@@ -85,8 +92,9 @@ class FileCacheMiddleware extends Middleware
     {
         $location = new FolderLocation($attributes['location']);
         $matchers = RequestResponseMatcher::buildMatchers($attributes['matchers'] ?? []);
+        $skipCacheHeader = $attributes['skip_cache_header'] ?? null;
 
-        return new self($location, $matchers);
+        return new self($location, $matchers, $skipCacheHeader);
     }
 
     /**
@@ -103,6 +111,10 @@ class FileCacheMiddleware extends Middleware
      */
     public function processRequest(ProcessingRequest $request): ProcessingRequest
     {
+        if ($this->shouldSkipCache($request)) {
+            return $request;
+        }
+
         foreach ($this->matchers as $matcher) {
             if (!$matcher->matchRequest($request)) {
                 return $request;
@@ -131,6 +143,10 @@ class FileCacheMiddleware extends Middleware
      */
     public function processResponse(Response $response): Response
     {
+        if ($this->shouldSkipCache($response->request())) {
+            return $response;
+        }
+
         if ($this->isCacheable($response)) {
             $cache = new FileCache($response->request(), $this->location);
             (new ResponseCacher($cache, $response))->process();
@@ -152,5 +168,21 @@ class FileCacheMiddleware extends Middleware
             }
         }
         return true;
+    }
+
+    /**
+     * Checks whether cache read/write should be bypassed for the current request.
+     *
+     * @param RequestInterface $request Current request.
+     * @return boolean True when skip header is configured and present, false otherwise.
+     */
+    private function shouldSkipCache(RequestInterface $request): bool
+    {
+        if ($this->skipCacheHeader === null) {
+            return false;
+        }
+
+        $normalizedHeaders = array_change_key_case($request->headers(), CASE_LOWER);
+        return array_key_exists(strtolower($this->skipCacheHeader), $normalizedHeaders);
     }
 }

--- a/source/source/lib/request_handlers/DefaultProxyRequestHandler.php
+++ b/source/source/lib/request_handlers/DefaultProxyRequestHandler.php
@@ -71,24 +71,32 @@ class DefaultProxyRequestHandler extends ProxyRequestHandler
      * @var array HTTP status codes eligible for caching
      */
     private array $cacheCodes;
+    /**
+     * @var string|null Header name that forces cache bypass when present.
+     */
+    private ?string $skipCacheHeader;
 
     /**
      * Constructs a DefaultProxyRequestHandler.
      *
-     * @param string                   $host       The target host to proxy requests to.
-     * @param string|false             $cache      Cache directory, or false to disable caching. Defaults to './cache'.
-     * @param array                    $cacheCodes HTTP status codes eligible for caching. Defaults to ['2xx'].
-     * @param HttpClientInterface|null $httpClient Optional HTTP client.
+     * @param string                   $host            The target host to proxy requests to.
+     * @param string|false             $cache           Cache directory, or false to disable caching.
+     *   Defaults to './cache'.
+     * @param array                    $cacheCodes      HTTP status codes eligible for caching. Defaults to ['2xx'].
+     * @param HttpClientInterface|null $httpClient      Optional HTTP client.
+     * @param string|null              $skipCacheHeader Header name that disables cache read/write when present.
      */
     public function __construct(
         string $host,
         string|false $cache,
         array $cacheCodes,
-        ?HttpClientInterface $httpClient = null
+        ?HttpClientInterface $httpClient = null,
+        ?string $skipCacheHeader = null
     ) {
         parent::__construct($host, $httpClient);
         $this->cache = $cache;
         $this->cacheCodes = $cacheCodes;
+        $this->skipCacheHeader = $skipCacheHeader;
         $this->initializeMiddlewares();
     }
 
@@ -99,6 +107,7 @@ class DefaultProxyRequestHandler extends ProxyRequestHandler
      *   - 'host' (string, required): Target host URL.
      *   - 'cache' (string|false): Cache directory or false to disable. Defaults to './cache'.
      *   - 'cacheCodes' (array): HTTP codes to cache. Defaults to ['2xx'].
+     *   - 'skip_cache_header' (string): Header name that disables cache read/write when present.
      * @return self
      * @throws \InvalidArgumentException If 'host' is missing.
      */
@@ -110,7 +119,8 @@ class DefaultProxyRequestHandler extends ProxyRequestHandler
         $host = $params['host'];
         $cache = array_key_exists('cache', $params) ? $params['cache'] : './cache';
         $cacheCodes = $params['cacheCodes'] ?? ['2xx'];
-        return new self($host, $cache, $cacheCodes);
+        $skipCacheHeader = $params['skip_cache_header'] ?? null;
+        return new self($host, $cache, $cacheCodes, null, $skipCacheHeader);
     }
 
     /**
@@ -125,7 +135,8 @@ class DefaultProxyRequestHandler extends ProxyRequestHandler
         if ($this->cache !== false) {
             $this->addMiddleware(new FileCacheMiddleware(
                 new FolderLocation($this->cache),
-                [new StatusCodeMatcher($this->cacheCodes)]
+                [new StatusCodeMatcher($this->cacheCodes)],
+                $this->skipCacheHeader
             ));
         }
     }

--- a/source/tests/unit/lib/middlewares/FileCacheMiddleware/FileCacheMiddlewareProcessRequestTest.php
+++ b/source/tests/unit/lib/middlewares/FileCacheMiddleware/FileCacheMiddlewareProcessRequestTest.php
@@ -157,9 +157,57 @@ class FileCacheMiddlewareProcessRequestTest extends TestCase
         $middleware->processRequest($this->request);
     }
 
-    private function buildRequest(string $path, string $method): ProcessingRequest
+    public function testProcessRequestWithSkipCacheHeaderConfiguredAndMissingKeepsCurrentBehavior()
+    {
+        $this->path = '/file.txt';
+        $this->request = $this->buildRequest($this->path, 'GET');
+        $this->buildCache();
+
+        $middleware = $this->buildMiddleware([
+            'skip_cache_header' => 'X-Skip-Cache'
+        ]);
+        $result = $middleware->processRequest($this->request);
+
+        $this->assertTrue($result->hasResponse());
+    }
+
+    public function testProcessRequestSkipsCacheReadWhenSkipCacheHeaderIsPresent()
+    {
+        $this->path = '/file.txt';
+        $this->request = $this->buildRequest($this->path, 'GET', [
+            'X-Skip-Cache' => '1'
+        ]);
+        $this->buildCache();
+
+        $middleware = $this->buildMiddleware([
+            'skip_cache_header' => 'X-Skip-Cache'
+        ]);
+        $result = $middleware->processRequest($this->request);
+
+        $this->assertFalse($result->hasResponse());
+        $this->assertSame($this->request, $result);
+    }
+
+    public function testProcessRequestSkipsCacheReadCaseInsensitively()
+    {
+        $this->path = '/file.txt';
+        $this->request = $this->buildRequest($this->path, 'GET', [
+            'x-skip-cache' => '1'
+        ]);
+        $this->buildCache();
+
+        $middleware = $this->buildMiddleware([
+            'skip_cache_header' => 'X-SKIP-CACHE'
+        ]);
+        $result = $middleware->processRequest($this->request);
+
+        $this->assertFalse($result->hasResponse());
+    }
+
+    private function buildRequest(string $path, string $method, array $headers = []): ProcessingRequest
     {
         return new ProcessingRequest([
+            'headers' => $headers,
             'requestPath' => $path,
             'requestMethod' => $method
         ]);

--- a/source/tests/unit/lib/middlewares/FileCacheMiddleware/FileCacheMiddlewareProcessResponseTest.php
+++ b/source/tests/unit/lib/middlewares/FileCacheMiddleware/FileCacheMiddlewareProcessResponseTest.php
@@ -101,11 +101,71 @@ class FileCacheMiddlewareProcessResponseTest extends TestCase
         $this->assertEquals(["Header1: original", "Header2: value"], $meta['headers']);
     }
 
-    private function buildResponse(int $httpCode)
+    public function testProcessResponseWithSkipCacheHeaderConfiguredAndMissingKeepsCurrentBehavior()
+    {
+        $response = $this->buildResponse(200);
+
+        $middleware = FileCacheMiddleware::build([
+            'location' => $this->cacheDir,
+            'skip_cache_header' => 'X-Skip-Cache',
+            'matchers' => [
+                [
+                    'class' => \Tent\Matchers\StatusCodeMatcher::class,
+                    'httpCodes' => [200],
+                ]
+            ],
+        ]);
+        $middleware->processResponse($response);
+
+        $this->cache = new FileCache($this->request, $this->location);
+        $this->assertTrue($this->cache->exists());
+    }
+
+    public function testProcessResponseSkipsCacheWriteWhenSkipCacheHeaderIsPresent()
+    {
+        $response = $this->buildResponse(200, ['X-Skip-Cache' => '1']);
+
+        $middleware = FileCacheMiddleware::build([
+            'location' => $this->cacheDir,
+            'skip_cache_header' => 'X-Skip-Cache',
+            'matchers' => [
+                [
+                    'class' => \Tent\Matchers\StatusCodeMatcher::class,
+                    'httpCodes' => [200],
+                ]
+            ],
+        ]);
+        $middleware->processResponse($response);
+
+        $this->cache = new FileCache($this->request, $this->location);
+        $this->assertFalse($this->cache->exists());
+    }
+
+    public function testProcessResponseSkipsCacheWriteCaseInsensitively()
+    {
+        $response = $this->buildResponse(200, ['x-skip-cache' => '1']);
+
+        $middleware = FileCacheMiddleware::build([
+            'location' => $this->cacheDir,
+            'skip_cache_header' => 'X-SKIP-CACHE',
+            'matchers' => [
+                [
+                    'class' => \Tent\Matchers\StatusCodeMatcher::class,
+                    'httpCodes' => [200],
+                ]
+            ],
+        ]);
+        $middleware->processResponse($response);
+
+        $this->cache = new FileCache($this->request, $this->location);
+        $this->assertFalse($this->cache->exists());
+    }
+
+    private function buildResponse(int $httpCode, array $requestHeaders = [])
     {
         $this->path = '/file.txt';
         $this->headers = ['Content-Type: text/plain', 'Content-Length: 11'];
-        $this->request = $this->buildRequest($this->path, 'GET');
+        $this->request = $this->buildRequest($this->path, 'GET', $requestHeaders);
 
         return new Response([
             'body' => 'cached body', 'httpCode' => $httpCode, 'headers' => $this->headers,
@@ -113,9 +173,10 @@ class FileCacheMiddlewareProcessResponseTest extends TestCase
         ]);
     }
 
-    private function buildRequest(string $path, string $method): ProcessingRequest
+    private function buildRequest(string $path, string $method, array $headers = []): ProcessingRequest
     {
         return new ProcessingRequest([
+            'headers' => $headers,
             'requestPath' => $path,
             'requestMethod' => $method
         ]);

--- a/source/tests/unit/lib/request_handlers/DefaultProxyRequestHandler/DefaultProxyRequestHandlerCachedTest.php
+++ b/source/tests/unit/lib/request_handlers/DefaultProxyRequestHandler/DefaultProxyRequestHandlerCachedTest.php
@@ -11,6 +11,7 @@ use Tent\Models\Response;
 use Tent\Tests\Support\Utils\FileSystemUtils;
 use Tent\Models\FolderLocation;
 use Tent\Content\FileCache;
+use Tent\Http\HttpClientInterface;
 
 class DefaultProxyRequestHandlerCachedTest extends TestCase
 {
@@ -84,6 +85,42 @@ class DefaultProxyRequestHandlerCachedTest extends TestCase
         $response = $handler->handleRequest($this->request);
 
         $this->assertSame($this->cachedBody, $response->body());
+    }
+
+    public function testHandleRequestSkipsCacheWhenSkipCacheHeaderIsPresent()
+    {
+        $this->initVariables([
+            'requestHeaders' => [
+                'x-skip-cache' => '1'
+            ]
+        ]);
+        $this->buildCache();
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->willReturn([
+                'body' => 'upstream body',
+                'httpCode' => 200,
+                'headers' => ['Content-Type: text/plain']
+            ]);
+
+        $handler = DefaultProxyRequestHandler::build([
+            'type' => 'default_proxy',
+            'host' => $this->baseUrl,
+            'cache' => $this->cacheDir,
+            'cacheCodes' => ['2xx'],
+            'skip_cache_header' => 'X-SKIP-CACHE'
+        ]);
+
+        $reflection = new \ReflectionClass($handler);
+        $property = $reflection->getParentClass()->getProperty('httpClient');
+        $property->setAccessible(true);
+        $property->setValue($handler, $httpClient);
+
+        $response = $handler->handleRequest($this->request);
+
+        $this->assertSame('upstream body', $response->body());
     }
 
     private function initVariables(array $overrides = []): void


### PR DESCRIPTION
This change introduces an optional cache-bypass header for `FileCacheMiddleware`: when configured and present on a request, caching is bypassed entirely for that request lifecycle. It also exposes the same option on `default_proxy` handler config and forwards it to the cache middleware.

- **Middleware behavior (`FileCacheMiddleware`)**
  - Adds optional `skip_cache_header` config.
  - Request phase: skips cache lookup when the configured header is present.
  - Response phase: skips cache storage for responses tied to requests containing that header.
  - Header matching is case-insensitive (HTTP semantics).

- **Default proxy config passthrough (`DefaultProxyRequestHandler`)**
  - Extends handler build/config with optional `skip_cache_header`.
  - Forwards the value into the internally created `FileCacheMiddleware`.
  - Preserves existing behavior when option is absent.

- **Unit test coverage updates**
  - Verifies unchanged behavior when `skip_cache_header` is not configured.
  - Verifies normal caching when configured but header is absent.
  - Verifies no cache read/write when configured header is present.
  - Verifies case-insensitive header-name matching.
  - Verifies top-level `default_proxy` config path applies the bypass behavior.

```php
Configuration::buildRule([
    'handler' => [
        'type' => 'default_proxy',
        'host' => 'http://api:80',
        'cache' => './cache',
        'cacheCodes' => ['2xx'],
        'skip_cache_header' => 'X-Skip-Cache'
    ],
    'matchers' => [
        ['method' => 'GET', 'uri' => '/api/', 'type' => 'begins_with']
    ]
]);
```

Fixes #217